### PR TITLE
Support new default galaxy name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 oVirt Virtual Machine Infrastructure
 ====================================
 
-The `oVirt.vm-infra` role manages the virtual machine infrastructure in oVirt.
+The `ovirt.vm-infra` role manages the virtual machine infrastructure in oVirt.
 This role also creates inventory of created virtual machines it defines if
 `wait_for_ip` is set to `true` and state of virtual machine is `running`.
 All defined virtual machine are part of `ovirt_vm` inventory group.
@@ -26,6 +26,24 @@ The role will create inventory groups `ovirt_vm` where will be both virtual
 machines `myvm1` and `myvm2`. The role also create inventory groups `ovirt_tag_mytag1`
 with virtual machine `myvm1` and inventory group `ovirt_tag_mytag2` with virtual
 machine `myvm2`.
+
+Note
+----
+Please note that when installing this role from Ansible Galaxy you are instructed to run following command:
+
+```bash
+$ ansible-galaxy install ovirt.vm-infra
+```
+
+This will download the role to the directory with the same name as you specified on the
+command line, in this case `ovirt.vm-infra`. But note that it is case sensitive, so if you specify
+for example `OVIRT.vm-infra` it will download the same role, but it will add it to the directory named
+`OVIRT.vm-infra`, so you later always have to use this role with upper case prefix. So be careful how
+you specify the name of the role on command line.
+
+For the RPM installation we install three legacy names `ovirt.vm-infra`, `oVirt.vm-infra` and `ovirt-vm-infra`.
+So you can use any of this name. This documentation and examples in this repository are using name `ovirt.vm-infra`.
+`oVirt.vm-infra` and `ovirt-vm-infra` role names are deprecated.
 
 Requirements
 ------------
@@ -238,10 +256,10 @@ Example Playbook
           - postgresql-vm-1
 
   roles:
-    - oVirt.vm-infra
+    - ovirt.vm-infra
 ```
 
-The example below shows how to use inventory created by `oVirt.vm-infra` role in follow up play.
+The example below shows how to use inventory created by `ovirt.vm-infra` role in follow up play.
 
 ```yaml
 ---
@@ -277,7 +295,7 @@ The example below shows how to use inventory created by `oVirt.vm-infra` role in
         profile: "{{ httpd_vm }}"
 
   roles:
-    - oVirt.vm-infra
+    - ovirt.vm-infra
 
 - name: Deploy apache on VM
   hosts: ovirt_tag_apache

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ VERSION="1.1.12"
 MILESTONE=master
 RPM_RELEASE="0.1.$MILESTONE.$(date -u +%Y%m%d%H%M%S)"
 
-ROLE_NAME="oVirt.vm-infra"
+ROLE_NAME="ovirt.vm-infra"
 PACKAGE_NAME="ovirt-ansible-vm-infra"
 PREFIX=/usr/local
 DATAROOT_DIR=$PREFIX/share
@@ -14,6 +14,7 @@ PKG_DATA_DIR=${PKG_DATA_DIR:-$ROLES_DATAROOT_DIR/$PACKAGE_NAME}
 PKG_DATA_DIR_ORIG=${PKG_DATA_DIR_ORIG:-$PKG_DATA_DIR}
 PKG_DOC_DIR=${PKG_DOC_DIR:-$DOC_DIR/$PACKAGE_NAME}
 ROLENAME_LEGACY="${ROLENAME_LEGACY:-$ROLES_DATAROOT_DIR/ovirt-vm-infra}"
+ROLENAME_LEGACY_UPPERCASE="${ROLENAME_LEGACY_UPPERCASE:-$ROLES_DATAROOT_DIR/oVirt.vm-infra}"
 
 RPM_VERSION=$VERSION
 PACKAGE_VERSION=$VERSION
@@ -42,6 +43,9 @@ install() {
 
   # Create a symlink, so legacy role name does work:
   ln -f -s $PKG_DATA_DIR_ORIG $ROLENAME_LEGACY 
+
+  # Create a symlink, so legacy role name does work with upper case:
+  ln -f -s $PKG_DATA_DIR_ORIG $ROLENAME_LEGACY_UPPERCASE
   
   cp -pR defaults/ $PKG_DATA_DIR
   cp -pR library/ $PKG_DATA_DIR

--- a/examples/ovirt_vm_infra.yml
+++ b/examples/ovirt_vm_infra.yml
@@ -9,9 +9,9 @@
     - passwords.yml
 
   vars:
-    #engine_url: https://ovirt-engine.example.com/ovirt-engine/api
-    #engine_user: admin@internal
-    #engine_cafile: /etc/pki/ovirt-engine/ca.pem
+    engine_url: https://ovirt-engine.example.com/ovirt-engine/api
+    engine_user: admin@internal
+    engine_cafile: /etc/pki/ovirt-engine/ca.pem
 
     debug_vm_create: yes
     db_vm:
@@ -35,12 +35,12 @@
         memory: 2GiB
         cloud_init:
           host_name: ps.example.com
-          root_password: '123456'
-          authorized_ssh_keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCjjbwFT/R0WicrlDHcuQjr11jmvb/0uQ46gbRZFpdes/1+xANwSRTaZh9yvZj6TRuH0aAHoVptfATEoXZ62hOfQaA0OOtWF5VOSFBTL+tCfSIGUSVkLJXL/ZxpaZnQ9usha1cpaE57V4lONBq0noj7kB4ks6ZMsI0qzAuYNiii2dEPGPZEX1wsq1OliJdwF9xdbQKp5Sg7JsoHvAV+I/hWcJ6wKj4vckuyn9X7+qftOC5es+zsLLp5PgLGxayYRcrieE5aQhQMAXa72Eutn6f0X0QXn9EqyjL/4T97htP+t+2pkR5/Bn6Ho4sUK164Jquzphh/Lmqu9OLUFWMh2LGx ondra@ondra
+          root_password: 'mypassword'
+          authorized_ssh_keys: ssh-rsa A...LGx ondra@ondra
         profile: "{{ db_vm }}"
         tag:
           - pgsql
           - httpd
 
   roles:
-    - oVirt.vm-infra
+    - ovirt.vm-infra

--- a/examples/ovirt_vm_infra_inv.yml
+++ b/examples/ovirt_vm_infra_inv.yml
@@ -46,7 +46,7 @@
         profile: db_vm
 
   roles:
-    - oVirt.vm-infra
+    - ovirt.vm-infra
 
 
 # This role also creates inventory of created virtual machines it defines if wait_for_ip is set to true

--- a/ovirt-ansible-vm-infra.spec.in
+++ b/ovirt-ansible-vm-infra.spec.in
@@ -1,6 +1,7 @@
 %global rolename vm-infra
-%global roleprefix oVirt.
+%global roleprefix ovirt.
 %global roleprefix_legacy ovirt-
+%global roleprefix_legacy_uppercase oVirt.
 %global ansible_roles_dir ansible/roles
 
 Name: @PACKAGE_NAME@
@@ -21,10 +22,17 @@ This Ansible role provide funtionality to create virtual machine infrastructure.
 %pretrans -p <lua>
 -- Remove the legacy directory before installing the symlink. This is known issue in RPM:
 -- https://fedoraproject.org/wiki/Packaging:Directory_Replacement
-path = "%{_datadir}/%{ansible_roles_dir}/%{roleprefix_legacy}%{rolename}"
-st = posix.stat(path)
+path_dash = "%{_datadir}/%{ansible_roles_dir}/%{roleprefix_legacy}%{rolename}"
+path_uppercase = "%{_datadir}/%{ansible_roles_dir}/%{roleprefix_legacy_uppercase}%{rolename}"
+
+st = posix.stat(path_dash)
 if st and st.type == "directory" then
-  os.execute('rm -rf "'..path..'"')
+  os.execute('rm -rf "'..path_dash..'"')
+end
+
+st = posix.stat(path_uppercase)
+if st and st.type == "directory" then
+  os.execute('rm -rf "'..path_uppercase..'"')
 end
 
 %prep
@@ -37,11 +45,13 @@ export PKG_DATA_DIR_ORIG=%{_datadir}/%{ansible_roles_dir}/%{roleprefix}%{rolenam
 export PKG_DATA_DIR=%{buildroot}$PKG_DATA_DIR_ORIG
 export PKG_DOC_DIR=%{buildroot}%{_pkgdocdir}
 export ROLENAME_LEGACY=%{buildroot}%{_datadir}/%{ansible_roles_dir}/%{roleprefix_legacy}%{rolename}
+export ROLENAME_LEGACY_UPPERCASE=%{buildroot}%{_datadir}/%{ansible_roles_dir}/%{roleprefix_legacy_uppercase}%{rolename}
 sh build.sh install
 
 %files
 %{_datadir}/%{ansible_roles_dir}/%{roleprefix}%{rolename}
 %{_datadir}/%{ansible_roles_dir}/%{roleprefix_legacy}%{rolename}
+%{_datadir}/%{ansible_roles_dir}/%{roleprefix_legacy_uppercase}%{rolename}
 
 %doc README.md
 %doc examples/


### PR DESCRIPTION
This patch add RPM support for ovirt.vm-infra name, as is default now in galaxy and add note about it in README.doc.

Change-Id: Ia38ae8cd986b4421a4b127d7f37eabe0ee6782d8
Signed-off-by: Ondra Machacek <omachace@redhat.com>