### PR TITLE
Adding support for cpu_mode and placement_policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ The `vms` and `profile` variables can contain following attributes, note that if
 | domain             | UNDEF                 | The domain of the virtual machine. This is parameter is keep for backward compatibility and has precendece before <i>host_name</i> in <i>cloud_init</i> dictionary.|
 | lease              | UNDEF                 | Name of the storage domain this virtual machine lease reside on. |
 | root_password      | UNDEF                 | The root password of the virtual machine. This is parameter is keep for backward compatibility and has precendece before <i>root_password</i> in <i>cloud_init</i> dictionary.|
+| cpu_mode           | UNDEF                 | CPU mode of the virtual machine. It can be some of the following: host_passthrough, host_model or custom. |
+| placement_policy   | UNDEF                 | The configuration of the virtual machine's placement policy. |
 
 The item in `disks` list of `profile` dictionary can contain following attributes:
 

--- a/tasks/create_vms.yml
+++ b/tasks/create_vms.yml
@@ -15,6 +15,8 @@
     cpu_sockets: "{{ current_vm.sockets | default(current_vm.profile.sockets) | default(omit) }}"
     cpu_shares: "{{ current_vm.cpu_shares | default(current_vm.profile.cpu_cores) | default(omit) }}"
     cpu_threads: "{{ current_vm.cpu_threads | default(current_vm.profile.cpu_threads) | default(omit) }}"
+    cpu_mode: "{{ current_vm.cpu_mode | default(current_vm.profile.cpu_mode) | default(omit) }}"
+    placement_policy: "{{ 'user_migratable' if ((current_vm.profile.cpu_mode is defined and current_vm.profile.cpu_mode == 'host_passthrough') or (current_vm.cpu_mode is defined and current_vm.cpu_mode == 'host_passthrough')) else current_vm.placement_policy | default(current_vm.profile.placement_policy) | default(omit) }}"
     custom_properties: "{{ current_vm.custom_properties | default(current_vm.profile.custom_properties) | default(omit) }}"
     description: "{{ current_vm.description | default(current_vm.profile.description) | default(omit) }}"
     operating_system: "{{ current_vm.operating_system | default(current_vm.profile.operating_system) | default(omit) }}"


### PR DESCRIPTION
Please add support for cpu_mode and related placement_policy, in the Web UI the placement_policy is automatically configured to manual migration when host cpu pass-through is set, I've tried to reproduce this behavior.