### PR TITLE
Add boot_devices to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The `vms` and `profile` variables can contain following attributes, note that if
 | root_password      | UNDEF                 | The root password of the virtual machine. This is parameter is keep for backward compatibility and has precendece before <i>root_password</i> in <i>cloud_init</i> dictionary.|
 | cpu_mode           | UNDEF                 | CPU mode of the virtual machine. It can be some of the following: host_passthrough, host_model or custom. |
 | placement_policy   | UNDEF                 | The configuration of the virtual machine's placement policy. |
+| boot_devices       | UNDEF                 | List of boot devices which should be used to boot. Valid entries are `cdrom`, `hd`, `network`. |
 
 The item in `disks` list of `profile` dictionary can contain following attributes:
 

--- a/tasks/create_vms.yml
+++ b/tasks/create_vms.yml
@@ -16,6 +16,7 @@
     cpu_shares: "{{ current_vm.cpu_shares | default(current_vm.profile.cpu_cores) | default(omit) }}"
     cpu_threads: "{{ current_vm.cpu_threads | default(current_vm.profile.cpu_threads) | default(omit) }}"
     cpu_mode: "{{ current_vm.cpu_mode | default(current_vm.profile.cpu_mode) | default(omit) }}"
+    boot_devices: "{{ current_vm.boot_devices | default(current_vm.profile.boot_devices) | default(omit) }}"
     placement_policy: "{{ 'user_migratable' if ((current_vm.profile.cpu_mode is defined and current_vm.profile.cpu_mode == 'host_passthrough') or (current_vm.cpu_mode is defined and current_vm.cpu_mode == 'host_passthrough')) else current_vm.placement_policy | default(current_vm.profile.placement_policy) | default(omit) }}"
     custom_properties: "{{ current_vm.custom_properties | default(current_vm.profile.custom_properties) | default(omit) }}"
     description: "{{ current_vm.description | default(current_vm.profile.description) | default(omit) }}"


### PR DESCRIPTION
`boot_devices` is a valid setting for `ovirt_vm` to allow the boot order of the VM to be set. We use this since our VMs are provisioned via PXE.