### PR TITLE
Corrected inconsistent use of tabs vs spaces in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The item in `disks` list of `profile` dictionary can contain following attribute
 | name               | UNDEF          | The name of the additional disk.  |
 | storage_domain     | UNDEF          | The name of storage domain where disk should be created. |
 | interface          | UNDEF          | The interface of the disk. |
-| name_prefix		     | True           | If true the name of the vm will be used as prefix of disk name. If false only the name of disk will be used as disk name - could be useful when creating vm from template with custom disk size. |
+| name_prefix        | True           | If true the name of the vm will be used as prefix of disk name. If false only the name of disk will be used as disk name - could be useful when creating vm from template with custom disk size. |
 | format             | UNDEF          | Specify format of the disk.  <ul><li>cow - If set, the disk will by created as sparse disk, so space will be allocated for the volume as needed. This format is also known as thin provisioned disks</li><li>raw - If set, disk space will be allocated right away. This format is also known as preallocated disks.</li></ul> |
 | bootable           | UNDEF          | True if the disk should be bootable. |
 


### PR DESCRIPTION
README.md had inconsistent use of tabs in the table markdown. It's pedantic, but frustrating in my IDE while perusing things.