### PR TITLE
Add option to configure Affinity labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,16 @@ The `affinity_groups` list can contain following attributes:
 | vms                | UNDEF               |  List of VM's to be assigned to this affinity group. |
 | wait               | true                |  If true, the module will wait for the desired state. |
 
+The `affinity_labels` list can contain following attributes:
+
+| Name               | Default value       |                                              |
+|--------------------|---------------------|----------------------------------------------|
+| cluster            | UNDEF (Required)    |  Name of the cluster of the affinity label group.  |
+| hosts              | UNDEF               |  List of host names assigned to this label.  |
+| name               | UNDEF (Required)    |  Name of affinity label.                     |
+| state              | UNDEF               |  Whether label should be present or absent.  |
+| vms                | UNDEF               |  List of VM's to be assigned to this affinity label. |
+
 The `cloud_init` dictionary can contain following attributes:
 
 | Name                | Description                                          |

--- a/tasks/affinity_labels.yml
+++ b/tasks/affinity_labels.yml
@@ -1,0 +1,13 @@
+---
+- name: Create affinity labels
+  ovirt_affinity_label:
+    auth: "{{ ovirt_auth }}"
+    cluster: "{{ item.cluster | default(omit) }}"
+    hosts: "{{ item.hosts | default(omit) }}"
+    name: "{{ item.name }}"
+    state: "{{ item.state | default(omit) }}"
+    vms: "{{ item.vms | default([]) }}"
+  with_items:
+    - "{{ affinity_labels | default([]) }}"
+  tags:
+    - affinity_labels

--- a/tasks/vm_state_present.yml
+++ b/tasks/vm_state_present.yml
@@ -17,6 +17,9 @@
 - name: Apply any Affinity Groups
   import_tasks: affinity_groups.yml
 
+- name: Apply any Affinity Labels
+  import_tasks: affinity_labels.yml
+
 - name: Manage profile disks
   ovirt_disk29:
     auth: "{{ ovirt_auth }}"


### PR DESCRIPTION
oVirt affinity labels is an easy solution to create a subcluster
within a cluster. Adding this to VM infra role will allow users to
schedule the VMs to a set of hosts.