### PR TITLE
sysprep and cloud_init check when vars are defined

### DIFF
--- a/tasks/manage_state.yml
+++ b/tasks/manage_state.yml
@@ -6,21 +6,22 @@
   - set_fact:
       cloud_init: "{{ current_vm.cloud_init | default(current_vm.profile.cloud_init) | default({}) }}"
 
-  - set_fact:
-      cloud_init: "{{ cloud_init | combine({'user_name': cloud_init.user_name | default('root') }) }}"
+  - block:
+    - set_fact:
+        cloud_init: "{{ cloud_init | combine({'user_name': cloud_init.user_name | default('root') }) }}"
+
+    - set_fact:
+        cloud_init: "{{ cloud_init | combine({'authorized_ssh_keys': current_vm.ssh_key | default(current_vm.profile.ssh_key)}) }}"
+      when: current_vm.profile.ssh_key is defined or current_vm.ssh_key is defined
+
+    - set_fact:
+        cloud_init: "{{ cloud_init | combine({'root_password': current_vm.root_password | default(current_vm.profile.root_password)}) }}"
+      when: current_vm.profile.root_password is defined or current_vm.root_password is defined
+
+    - set_fact:
+        cloud_init: "{{ cloud_init | combine({'host_name': current_vm.name~'.'~current_vm.domain | default(current_vm.profile.domain)}) }}"
+      when: current_vm.profile.domain is defined or current_vm.domain is defined
     when: current_vm.cloud_init is defined or current_vm.profile.cloud_init is defined
-
-  - set_fact:
-      cloud_init: "{{ cloud_init | combine({'authorized_ssh_keys': current_vm.ssh_key | default(current_vm.profile.ssh_key)}) }}"
-    when: current_vm.profile.ssh_key is defined or current_vm.ssh_key is defined
-
-  - set_fact:
-      cloud_init: "{{ cloud_init | combine({'root_password': current_vm.root_password | default(current_vm.profile.root_password)}) }}"
-    when: current_vm.profile.root_password is defined or current_vm.root_password is defined
-
-  - set_fact:
-      cloud_init: "{{ cloud_init | combine({'host_name': current_vm.name~'.'~current_vm.domain | default(current_vm.profile.domain)}) }}"
-    when: current_vm.profile.domain is defined or current_vm.domain is defined
 
   - name: Define vm/password dictionary
     set_fact:
@@ -36,17 +37,18 @@
   - set_fact:
       sysprep: "{{ current_vm.sysprep | default(current_vm.profile.sysprep) | default({}) }}"
 
-  - set_fact:
-      sysprep: "{{ sysprep | combine({'user_name': sysprep.user_name | default('Administrator') }) }}"
+  - block:
+    - set_fact:
+        sysprep: "{{ sysprep | combine({'user_name': sysprep.user_name | default('Administrator') }) }}"
+
+    - set_fact:
+        sysprep: "{{ sysprep | combine({'root_password': current_vm.root_password | default(current_vm.profile.root_password)}) }}"
+      when: current_vm.profile.root_password is defined or current_vm.root_password is defined
+
+    - set_fact:
+        sysprep: "{{ sysprep | combine({'host_name': current_vm.name~'.'~current_vm.domain | default(current_vm.profile.domain)}) }}"
+      when: current_vm.profile.domain is defined or current_vm.domain is defined
     when: current_vm.sysprep is defined or current_vm.profile.sysprep is defined
-
-  - set_fact:
-      sysprep: "{{ sysprep | combine({'root_password': current_vm.root_password | default(current_vm.profile.root_password)}) }}"
-    when: current_vm.profile.root_password is defined or current_vm.root_password is defined
-
-  - set_fact:
-      sysprep: "{{ sysprep | combine({'host_name': current_vm.name~'.'~current_vm.domain | default(current_vm.profile.domain)}) }}"
-    when: current_vm.profile.domain is defined or current_vm.domain is defined
 
   - name: Define vm/password dictionary
     set_fact:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1744499#c1
@machacekondra 

Issue was when user defined root_password in vm instead of in cloud_init or sysprep it would failed because it passed the password to both.
This issue could also happen with domain or ssh_key.

i put code to blocks and checked if user used sysprep or cloud_init.