### PR TITLE
Removed unnecessary conditions when creating vm disks/nics

### DIFF
--- a/tasks/vm_state_present.yml
+++ b/tasks/vm_state_present.yml
@@ -54,7 +54,6 @@
     activate: "{{ item.1.activate | default(omit) }}"
     wait: true
   # When there is profile with disks, vms disks will update them
-  when: item.0.profile is defined and item.0.profile.disks is defined
   with_subelements:
     - "{{ create_vms }}"
     - "disks"
@@ -70,7 +69,7 @@
     mac_address: "{{ item.1.mac_address | default(omit) }}"
     profile: "{{ item.1.profile | default(omit) }}"
     network: "{{ item.1.network | default(omit) }}"
-  # When there is no profile NICs it will use vms disks
+  # When there is no profile NICs it will use vms NICs
   with_subelements:
     - "{{ create_vms }}"
     - "profile.nics"
@@ -87,7 +86,6 @@
     profile: "{{ item.1.profile | default(omit) }}"
     network: "{{ item.1.network | default(omit) }}"
   # When there is profile with nics, vms nics will update them
-  when: item.0.profile is defined and item.0.profile.nics is defined
   with_subelements:
     - "{{ create_vms }}"
     - "nics"


### PR DESCRIPTION
This PR fixes issues, which I describe here: https://github.com/oVirt/ovirt-ansible-vm-infra/pull/95#pullrequestreview-309846022

This conditionals which I removed enables to add disk to vm which have template, which doesn't have specified any.

Same apply to removed conditional in task manage vm nic.

Also i fixed typo in comment about nics
