### PR TITLE
fix VM pinning missing host attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The `vms` and `profile` variables can contain following attributes, note that if
 | domain             | UNDEF                 | The domain of the virtual machine. This is parameter is keep for backward compatibility and has precendece before <i>host_name</i> in <i>cloud_init</i> or <i>sysprep</i> dictionary.|
 | lease              | UNDEF                 | Name of the storage domain this virtual machine lease reside on. |
 | root_password      | UNDEF                 | The root password of the virtual machine. This is parameter is keep for backward compatibility and has precendece before <i>root_password</i> in <i>cloud_init</i> or <i>sysprep</i> dictionary.|
+| host               | UNDEF                 | If you need to set cpu_mode as host_passthrough, you need to use this param to define host to use along with placement_policy set to pinned. |
 | cpu_mode           | UNDEF                 | CPU mode of the virtual machine. It can be some of the following: host_passthrough, host_model or custom. |
 | placement_policy   | UNDEF                 | The configuration of the virtual machine's placement policy. |
 | boot_devices       | UNDEF                 | List of boot devices which should be used to boot. Valid entries are `cdrom`, `hd`, `network`. |

--- a/tasks/create_vms.yml
+++ b/tasks/create_vms.yml
@@ -9,6 +9,7 @@
     template: "{{ current_vm.template | default(current_vm.profile.template) | default(omit) }}"
     template_version: "{{ current_vm.template_version | default(current_vm.profile.template_version) | default(omit) }}"
     ballooning_enabled: "{{ current_vm.ballooning_enabled | default(current_vm.profile.ballooning_enabled) | default(omit) }}"
+    host: "{{ current_vm.host | default(current_vm.profile.host) | default(omit) }}"
     memory: "{{ current_vm.memory | default(current_vm.profile.memory) | default(omit) }}"
     memory_max: "{{ current_vm.memory_max | default(current_vm.profile.memory_max) | default(omit) }}"
     memory_guaranteed: "{{ current_vm.memory_guaranteed | default(current_vm.profile.memory_guaranteed) | default(omit) }}"


### PR DESCRIPTION
In existing create_vms.yml, `host` attribute was missing, which is required if you need to use `cpu_host` mode `pinned`