### PR TITLE
Add comment field to ovirt_vm_infra role

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The `vms` and `profile` variables can contain following attributes, note that if
 | serial_console     | UNDEF                 | True enable VirtIO serial console, False to disable it. By default is chosen by oVirt/RHV engine. |
 | serial_policy      | UNDEF                 | Specify a serial number policy for the Virtual Machine. Following options are supported. <br/><i>vm</i> - Sets the Virtual Machine's UUID as its serial number. <br/><i>host</i> - Sets the host's UUID as the Virtual Machine's serial number. <br/><i>custom</i> - Allows you to specify a custom serial number in serial_policy_value. |
 | serial_policy_value | UNDEF                 | Allows you to specify a custom serial number. This parameter is used only when <i>serial_policy</i> is custom. |
+| comment | UNDEF                             | Comment of the virtual Machine. |
 
 The item in `disks` list of `profile` dictionary can contain following attributes:
 

--- a/tasks/create_vms.yml
+++ b/tasks/create_vms.yml
@@ -34,6 +34,7 @@
     serial_policy : "{{ current_vm.serial_policy | default(current_vm.profile.serial_policy) | default(omit) }}"
     serial_policy_value : "{{ current_vm.serial_policy_value | default(current_vm.profile.serial_policy_value) | default(omit) }}"
     timeout: "{{ vm_infra_create_single_timeout }}"
+    comment: "{{ current_vm.comment | default(current_vm.profile.comment) | default(omit) }}"
   changed_when: false
   async: "{{ vm_infra_create_single_timeout }}"
   poll: 0


### PR DESCRIPTION
Currently this rôle support description flag of module ovirt_vm, This PR add support for comment field, this field is use to set comment on rhv vm