### PR TITLE
Add variable to merge profile variable and vms variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The `vms` and `profile` variables can contain following attributes, note that if
 | serial_policy      | UNDEF                 | Specify a serial number policy for the Virtual Machine. Following options are supported. <br/><i>vm</i> - Sets the Virtual Machine's UUID as its serial number. <br/><i>host</i> - Sets the host's UUID as the Virtual Machine's serial number. <br/><i>custom</i> - Allows you to specify a custom serial number in serial_policy_value. |
 | serial_policy_value | UNDEF                 | Allows you to specify a custom serial number. This parameter is used only when <i>serial_policy</i> is custom. |
 | comment | UNDEF                             | Comment of the virtual Machine. |
-| merge_with_profile | UNDEF,False           | Permit to merge vm level cloud_init and sysprep properties with profile level |
+| merge_with_profile | False                  | Permit to merge vm level cloud_init and sysprep properties with profile level |
 
 The item in `disks` list of `profile` dictionary can contain following attributes:
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The `vms` and `profile` variables can contain following attributes, note that if
 | serial_policy      | UNDEF                 | Specify a serial number policy for the Virtual Machine. Following options are supported. <br/><i>vm</i> - Sets the Virtual Machine's UUID as its serial number. <br/><i>host</i> - Sets the host's UUID as the Virtual Machine's serial number. <br/><i>custom</i> - Allows you to specify a custom serial number in serial_policy_value. |
 | serial_policy_value | UNDEF                 | Allows you to specify a custom serial number. This parameter is used only when <i>serial_policy</i> is custom. |
 | comment | UNDEF                             | Comment of the virtual Machine. |
+| merge_with_profile | UNDEF,False           | Permit to merge vm level cloud_init and sysprep properties with profile level |
 
 The item in `disks` list of `profile` dictionary can contain following attributes:
 
@@ -347,6 +348,61 @@ The example below shows how to use inventory created by `ovirt.vm-infra` role in
   roles:
     - geerlingguy.apache
 ```
+
+Example with merging profile field cloud_init (work same for sysprep field) :
+
+```yaml
+- name: Deploy apache VM
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars_files:
+    # Contains encrypted `engine_password` varibale using ansible-vault
+    - passwords.yml
+
+  vars:
+    wait_for_ip: true
+
+    httpd_vm:
+      cluster: production
+      state: running
+      domain: example.com
+      template: rhel7
+      memory: 2GiB
+      cloud_init:
+        user_name: "user-1"
+        dns_servers: "127.0.0.1"
+        root_password: "ThePassword"
+      cores: 2
+      disks:
+        - size: 10GiB
+          name: data
+          storage_domain: mynfsstorage
+          interface: virtio
+
+    vms:
+      - name: apache-vm
+        merge_with_profile: True
+        tag: apache
+        cloud_init:
+          host_name: "VM-1.example.com"
+        profile: "{{ httpd_vm }}"
+
+  roles:
+    - ovirt.vm-infra
+
+- name: Deploy apache on VM
+  hosts: ovirt_tag_apache
+
+  vars_files:
+    - apache_vars.yml
+
+  roles:
+    - geerlingguy.apache
+```
+
+Here `merge_with_profile: True` allow supporting cloud_init at two level in same time.
 
 [![asciicast](https://asciinema.org/a/111662.png)](https://asciinema.org/a/111662)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,5 @@ vm_infra_create_all_timeout: "{{ vm_infra_create_single_timeout * (vms | length)
 vm_infra_wait_for_ip_retries: 5
 vm_infra_wait_for_ip_delay: 5
 vms_passwords: []
+
+merge_with_profile: False

--- a/tasks/manage_state.yml
+++ b/tasks/manage_state.yml
@@ -4,7 +4,12 @@
 ########################################################################
 - block:
   - set_fact:
+      cloud_init: "{{ current_vm.profile.cloud_init | default({}) | combine(current_vm.cloud_init | default({}) ) }}"
+    when: current_vm.merge_with_profile is defined and current_vm.merge_with_profile == True
+
+  - set_fact:
       cloud_init: "{{ current_vm.cloud_init | default(current_vm.profile.cloud_init) | default({}) }}"
+    when: current_vm.merge_with_profile is not defined or current_vm.merge_with_profile == False
 
   - block:
     - set_fact:
@@ -35,7 +40,12 @@
 
 - block:
   - set_fact:
+      sysprep: "{{ current_vm.profile.sysprep | default({}) | combine(current_vm.sysprep | default({}) ) }}"
+    when: current_vm.merge_with_profile is defined and current_vm.merge_with_profile == True
+
+  - set_fact:
       sysprep: "{{ current_vm.sysprep | default(current_vm.profile.sysprep) | default({}) }}"
+    when: current_vm.merge_with_profile is not defined or current_vm.merge_with_profile == False
 
   - block:
     - set_fact:
@@ -55,6 +65,7 @@
       when: "'root_password' in sysprep"
     when: current_vm.sysprep is defined or current_vm.profile.sysprep is defined
   no_log: true
+
 ########################################################################
 ########################################################################
 

--- a/tasks/manage_state.yml
+++ b/tasks/manage_state.yml
@@ -5,11 +5,11 @@
 - block:
   - set_fact:
       cloud_init: "{{ current_vm.profile.cloud_init | default({}) | combine(current_vm.cloud_init | default({}) ) }}"
-    when: current_vm.merge_with_profile is defined and current_vm.merge_with_profile == True
+    when: current_vm.merge_with_profile is defined and current_vm.merge_with_profile
 
   - set_fact:
       cloud_init: "{{ current_vm.cloud_init | default(current_vm.profile.cloud_init) | default({}) }}"
-    when: current_vm.merge_with_profile is not defined or current_vm.merge_with_profile == False
+    when: current_vm.merge_with_profile is not defined or not current_vm.merge_with_profile
 
   - block:
     - set_fact:
@@ -41,11 +41,11 @@
 - block:
   - set_fact:
       sysprep: "{{ current_vm.profile.sysprep | default({}) | combine(current_vm.sysprep | default({}) ) }}"
-    when: current_vm.merge_with_profile is defined and current_vm.merge_with_profile == True
+    when: current_vm.merge_with_profile is defined and current_vm.merge_with_profile
 
   - set_fact:
       sysprep: "{{ current_vm.sysprep | default(current_vm.profile.sysprep) | default({}) }}"
-    when: current_vm.merge_with_profile is not defined or current_vm.merge_with_profile == False
+    when: current_vm.merge_with_profile is not defined or not current_vm.merge_with_profile
 
   - block:
     - set_fact:


### PR DESCRIPTION
currently cloud-init variables at vm level are prioritized over the cloud-init variables of profiles
same for sysprep variable. 

To relaxed this behavior we create new property merge_with_profile which allow to combine two level. cf exemple into [readme](./README.md)